### PR TITLE
Fixes integer update to orm reference update #8

### DIFF
--- a/odmf/db/dataset.py
+++ b/odmf/db/dataset.py
@@ -359,7 +359,11 @@ class Timeseries(Dataset):
         self.end = last.time
         dsnew.start = next.time
         records = self.records.filter(Record.time >= next.time)
-        records.update({'dataset': dsnew.id})
+
+        # updates records with orm reference
+        for record in records:
+            record.dataset = dsnew
+
         session.commit()
         return self, dsnew
 


### PR DESCRIPTION
https://github.com/jlu-ilr-hydro/odmf/blob/d4824f88ee2440bd095c28a93f42cc60656a7a3f/odmf/db/dataset.py#L362
this caused a sqlalchemy.ProgrammingError.
Now fixed with referencing the orm dataset objects instead.