### PR TITLE
Fix typo in data-flow.svg from 'verfies' to 'verifies'

### DIFF
--- a/graphics/data-flow.svg
+++ b/graphics/data-flow.svg
@@ -380,7 +380,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
          x="177.90131"
          y="169.58456"
-         id="tspan26">verfies</tspan></text><g
+         id="tspan26">verifies</tspan></text><g
        id="g12"
        transform="translate(-11.988759,41.328258)"><rect
          x="59.804379"


### PR DESCRIPTION
Just saw the typo when adding it to my thesis paper. 